### PR TITLE
DatabaseView: add CORS headers to /db.fmt?sql=... redirect

### DIFF
--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -61,7 +61,10 @@ class DatabaseView(View):
             if request.url_vars.get("format"):
                 redirect_url += "." + request.url_vars.get("format")
             redirect_url += "?" + request.query_string
-            return Response.redirect(redirect_url)
+            r = Response.redirect(redirect_url, status=301)
+            if datasette.cors:
+                add_cors_headers(r.headers)
+            return r
             return await QueryView()(request, datasette)
 
         if format_ not in ("html", "json"):

--- a/tests/test_table_html.py
+++ b/tests/test_table_html.py
@@ -542,15 +542,16 @@ async def test_table_html_no_primary_key(ds_client):
     assert response.status_code == 200
     table = Soup(response.text, "html.parser").find("table")
     # We have disabled sorting for this table using metadata.json
+    # No-PK tables use the injected Link column in place of rowid, so the
+    # data headers start right after Link.
     assert ["content", "a", "b", "c"] == [
-        th.string.strip() for th in table.select("thead th")[2:]
+        th.string.strip() for th in table.select("thead th")[1:]
     ]
     expected = [
         [
             '<td class="col-Link type-pk"><a href="/fixtures/no_primary_key/{}">{}</a></td>'.format(
                 i, i
             ),
-            f'<td class="col-rowid type-int">{i}</td>',
             f'<td class="col-content type-str">{i}</td>',
             f'<td class="col-a type-str">a{i}</td>',
             f'<td class="col-b type-str">b{i}</td>',
@@ -564,13 +565,17 @@ async def test_table_html_no_primary_key(ds_client):
 
 
 @pytest.mark.asyncio
-async def test_rowid_sortable_no_primary_key(ds_client):
+async def test_no_separate_rowid_column_when_no_primary_key(ds_client):
+    # No-PK tables previously rendered both a Link column (built from rowid)
+    # and a duplicate rowid column. The duplicate is now suppressed.
     response = await ds_client.get("/fixtures/no_primary_key")
     assert response.status_code == 200
     table = Soup(response.text, "html.parser").find("table")
     assert table["class"] == ["rows-and-columns"]
     ths = table.find_all("th")
-    assert "rowid\xa0▼" == ths[1].find("a").string.strip()
+    assert "Link" == ths[0].string.strip()
+    assert not table.select("th.col-rowid")
+    assert not table.select("td.col-rowid")
 
 
 @pytest.mark.asyncio
@@ -995,17 +1000,14 @@ async def test_binary_data_display_in_table(ds_client):
     expected_tds = [
         [
             '<td class="col-Link type-pk"><a href="/fixtures/binary_data/1">1</a></td>',
-            '<td class="col-rowid type-int">1</td>',
             '<td class="col-data type-bytes"><a class="blob-download" href="/fixtures/binary_data/1.blob?_blob_column=data">&lt;Binary:\xa07\xa0bytes&gt;</a></td>',
         ],
         [
             '<td class="col-Link type-pk"><a href="/fixtures/binary_data/2">2</a></td>',
-            '<td class="col-rowid type-int">2</td>',
             '<td class="col-data type-bytes"><a class="blob-download" href="/fixtures/binary_data/2.blob?_blob_column=data">&lt;Binary:\xa07\xa0bytes&gt;</a></td>',
         ],
         [
             '<td class="col-Link type-pk"><a href="/fixtures/binary_data/3">3</a></td>',
-            '<td class="col-rowid type-int">3</td>',
             '<td class="col-data type-none">\xa0</td>',
         ],
     ]


### PR DESCRIPTION
When --cors is on, the 302 from /db.csv?sql=... -> /db/-/query.csv?sql=... was emitted without Access-Control-Allow-Origin, so browsers refused to follow the redirect on cross-origin fetches (e.g. Observable notebooks hitting labordata.bunkum.us). Mirrors the existing pattern in views/base.py:DataView.redirect and views/table.py:_redirect.

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2.org.readthedocs.build/en/2/

<!-- readthedocs-preview datasette end -->