### PR TITLE
CustomJSONEncoder: serialize UUID and INTERVAL (timedelta)

### DIFF
--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -22,6 +22,7 @@ import time
 import types
 import secrets
 import shutil
+import uuid
 from typing import Iterable, List, Tuple
 import urllib
 import yaml
@@ -214,8 +215,14 @@ class CustomJSONEncoder(json.JSONEncoder):
         # DuckDB (sqlite3 returns these as strings, so SQLite never hit this).
         if isinstance(obj, (datetime.date, datetime.datetime, datetime.time)):
             return obj.isoformat()
+        if isinstance(obj, datetime.timedelta):
+            # DuckDB INTERVAL columns; no SQLite analogue.
+            return str(obj)
         if isinstance(obj, decimal.Decimal):
             return float(obj)
+        if isinstance(obj, uuid.UUID):
+            # DuckDB UUID columns; sqlite3 returns these as plain strings.
+            return str(obj)
         if isinstance(obj, bytes):
             # Does it encode to utf8?
             try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,11 +6,13 @@ from datasette.app import Datasette
 from datasette import utils
 from datasette.utils.asgi import Request
 from datasette.utils.sqlite import sqlite3
+import datetime
 import json
 import os
 import pathlib
 import pytest
 import tempfile
+import uuid
 from unittest.mock import patch
 
 
@@ -126,7 +128,17 @@ def test_path_from_row_pks(row, pks, expected_path):
             """
         {"CategoryID": 1, "Description": "Soft drinks", "Picture": {"$base64": true, "encoded": "FRwCx60F/g=="}}
     """.strip(),
-        )
+        ),
+        # DuckDB UUID columns arrive as uuid.UUID (sqlite3 returns plain strings)
+        (
+            {"id": uuid.UUID("3a2b1c00-0000-4000-8000-000000000001")},
+            '{"id": "3a2b1c00-0000-4000-8000-000000000001"}',
+        ),
+        # DuckDB INTERVAL columns arrive as datetime.timedelta
+        (
+            {"span": datetime.timedelta(days=1, hours=2)},
+            '{"span": "1 day, 2:00:00"}',
+        ),
     ],
 )
 def test_custom_json_encoder(obj, expected):


### PR DESCRIPTION
Fixes #16.

DuckDB returns `UUID` columns as `uuid.UUID` and `INTERVAL` as `datetime.timedelta`, neither of which `CustomJSONEncoder` handled — so `.json` on any row with a UUID column 500'd with *"Object of type UUID is not JSON serializable"*. `sqlite3` returns these as plain strings, so the SQLite backend never hit it.

### Fix
Handle both in `CustomJSONEncoder.default` alongside the existing `date`/`datetime`/`Decimal`/`bytes` cases (the same class of DuckDB-native-type gap), rather than coercing in the DuckDB backend. This keeps the real typed value flowing through the system and fixes serialization for any backend.

```python
if isinstance(obj, datetime.timedelta):
    return str(obj)
...
if isinstance(obj, uuid.UUID):
    return str(obj)
```

### Verification
- Unit: added UUID + INTERVAL cases to `test_custom_json_encoder`; full `tests/test_utils.py` passes (189).
- End-to-end: with the patched core, `/lm20/filing/147963.json` returns 200 (was 500), the UUID column renders as a JSON string, and `.csv` export works.

Found via a real-traffic replay of labordata.bunkum.us against the SQLite and DuckDB deployments (69 distinct URLs / 414 hits).

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--19.org.readthedocs.build/en/19/

<!-- readthedocs-preview datasette end -->