### PR TITLE
facets: suggest facets by column, not by SELECT alias

### DIFF
--- a/datasette-duckdb/tests/test_views.py
+++ b/datasette-duckdb/tests/test_views.py
@@ -43,3 +43,42 @@ def test_fk_label_expansion_empty_result_does_not_500(tmp_path):
 
     response = asyncio.run(fetch())
     assert response.status_code == 200
+
+
+def test_facet_suggestion_on_keyed_table_does_not_500(tmp_path):
+    # Facet suggestion ran `select <col> as value ... where value is not null
+    # group by value`, referencing the SELECT alias. SQLite resolves the alias;
+    # DuckDB rejects it for the primary-key column with "column <pk> must appear
+    # in the GROUP BY clause". Regression for the 500 browsing /opdr/ar_assets_fixed
+    # (a table with an integer pk) once faceting is enabled.
+    src = tmp_path / "source.db"
+    dst = tmp_path / "out.duckdb"
+    con = sqlite3.connect(str(src))
+    con.executescript("""
+        create table assets (
+            oid integer primary key,
+            asset_type text
+        );
+        insert into assets (oid, asset_type)
+            values (1, 'a'), (2, 'a'), (3, 'b'), (4, 'b'), (5, 'c');
+        """)
+    con.commit()
+    con.close()
+    convert_sqlite_to_duckdb(str(src), str(dst))
+
+    ds = Datasette(
+        config={"plugins": {"datasette-duckdb": {"databases": {"d": str(dst)}}}}
+    )
+
+    async def fetch():
+        await ds.invoke_startup()
+        # The HTML table view runs facet suggestion over every column, incl. the
+        # pk; previously this 500'd. ?asset_type=a also exercises the filtered view.
+        return [
+            await ds.client.get("/d/assets"),
+            await ds.client.get("/d/assets?asset_type=a"),
+        ]
+
+    plain, filtered = asyncio.run(fetch())
+    assert plain.status_code == 200
+    assert filtered.status_code == 200

--- a/datasette/facets.py
+++ b/datasette/facets.py
@@ -182,8 +182,8 @@ class ColumnFacet(Facet):
             suggested_facet_sql = """
                 with limited as (select * from ({sql}) limit {suggest_consider})
                 select {column} as value, count(*) as n from limited
-                where value is not null
-                group by value
+                where {column} is not null
+                group by {column}
                 limit {limit}
             """.format(
                 column=self._escape(column),


### PR DESCRIPTION
Fixes #17.

`ColumnFacet.suggest` generated facet-suggestion SQL that references the SELECT alias `value` in `WHERE`/`GROUP BY`:

```sql
select {column} as value, count(*) as n from limited
where value is not null
group by value
```

SQLite resolves the alias to the column, but DuckDB rejects it for the primary-key column with `Binder Error: column "<pk>" must appear in the GROUP BY clause`. Since facet **suggestion** runs over every column on the HTML table view, this 500s the whole page for any table with a pk once faceting is enabled — e.g. `/opdr/ar_assets_fixed` (`oid INTEGER PRIMARY KEY`).

### Fix
Reference the real `{column}` in `WHERE`/`GROUP BY` instead of the alias — standard SQL, valid on both engines (verified against DuckDB and SQLite). The `facet_results` query already groups by the real column; this aligns `suggest` with it.

### Verification
- New DuckDB regression test (keyed table, faceting on): `datasette-duckdb/tests/test_views.py`.
- Full `datasette-duckdb` suite (27) and core `tests/test_facets.py` (18) pass.
- End-to-end: `/opdr/ar_assets_fixed` and `/opdr/ar_assets_fixed?rpt_id=…` return 200 (were 500).

Found via a real-traffic replay of labordata.bunkum.us against the SQLite and DuckDB deployments (56 distinct URLs / 184 hits).

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--20.org.readthedocs.build/en/20/

<!-- readthedocs-preview datasette end -->