### PR TITLE
schema view: compose via introspector instead of a sqlite_master query

### DIFF
--- a/datasette-duckdb/tests/test_views.py
+++ b/datasette-duckdb/tests/test_views.py
@@ -43,3 +43,33 @@ def test_fk_label_expansion_empty_result_does_not_500(tmp_path):
 
     response = asyncio.run(fetch())
     assert response.status_code == 200
+
+
+def test_database_schema_page_does_not_500(tmp_path):
+    # /<db>/-/schema ran a hardcoded `... from sqlite_master` query, which
+    # DuckDB can't parse -> every schema page 500'd. It now composes from the
+    # introspector's table/view definitions. Regression for /<db>/-/schema.
+    src = tmp_path / "source.db"
+    dst = tmp_path / "out.duckdb"
+    con = sqlite3.connect(str(src))
+    con.executescript("""
+        create table widget (id integer primary key, name text);
+        create view widget_names as select name from widget;
+        insert into widget (id, name) values (1, 'a'), (2, 'b');
+        """)
+    con.commit()
+    con.close()
+    convert_sqlite_to_duckdb(str(src), str(dst))
+
+    ds = Datasette(
+        config={"plugins": {"datasette-duckdb": {"databases": {"d": str(dst)}}}}
+    )
+
+    async def fetch():
+        await ds.invoke_startup()
+        return await ds.client.get("/d/-/schema.json")
+
+    response = asyncio.run(fetch())
+    assert response.status_code == 200
+    schema = response.json()["schema"]
+    assert "widget" in schema  # composed CREATE statements present

--- a/datasette/backends/__init__.py
+++ b/datasette/backends/__init__.py
@@ -349,6 +349,22 @@ class Introspector:
     async def get_table_definition(self, table, type_="table"):
         raise NotImplementedError
 
+    async def database_schema(self):
+        """Full schema for the database: the CREATE statements for every table
+        and view, concatenated. Composed from ``get_table_definition`` so it
+        works on any backend; ``SqliteIntrospector`` overrides it to preserve
+        its exact historical output."""
+        parts = []
+        for table in await self.table_names():
+            definition = await self.get_table_definition(table, "table")
+            if definition:
+                parts.append(definition)
+        for view in await self.view_names():
+            definition = await self.get_table_definition(view, "view")
+            if definition:
+                parts.append(definition)
+        return "\n".join(parts)
+
     async def attached_databases(self):
         raise NotImplementedError
 

--- a/datasette/backends/sqlite.py
+++ b/datasette/backends/sqlite.py
@@ -313,6 +313,17 @@ class SqliteIntrospector(Introspector):
             bits.append(index_row[0] + ";")
         return "\n".join(bits)
 
+    async def database_schema(self):
+        # Preserve the exact historical output (single sqlite_master dump) rather
+        # than the base class's per-table composition, so existing /-/schema
+        # output and tests are unchanged.
+        result = await self.db.execute(
+            "select group_concat(sql, ';' || CHAR(10)) as schema "
+            "from sqlite_master where sql is not null"
+        )
+        row = result.first()
+        return row["schema"] if row and row["schema"] else ""
+
     async def hidden_table_names(self):
         hidden_tables = []
         # Add any tables marked as hidden in config

--- a/datasette/database.py
+++ b/datasette/database.py
@@ -618,6 +618,9 @@ class Database:
     async def get_table_definition(self, table, type_="table"):
         return await self.introspector.get_table_definition(table, type_)
 
+    async def database_schema(self):
+        return await self.introspector.database_schema()
+
     async def get_view_definition(self, view):
         return await self.get_table_definition(view, "view")
 

--- a/datasette/views/special.py
+++ b/datasette/views/special.py
@@ -989,13 +989,9 @@ class SchemaBaseView(BaseView):
     has_json_alternate = False
 
     async def get_database_schema(self, database_name):
-        """Get schema SQL for a database."""
+        """Get schema SQL for a database (backend-agnostic, via the introspector)."""
         db = self.ds.databases[database_name]
-        result = await db.execute(
-            "select group_concat(sql, ';' || CHAR(10)) as schema from sqlite_master where sql is not null"
-        )
-        row = result.first()
-        return row["schema"] if row and row["schema"] else ""
+        return await db.database_schema()
 
     def format_json_response(self, data):
         """Format data as JSON response with CORS headers if needed."""


### PR DESCRIPTION
Fixes #21.

`SchemaBaseView.get_database_schema` (`datasette/views/special.py`) ran a hardcoded SQLite query:

```python
"select group_concat(sql, ';' || CHAR(10)) as schema from sqlite_master where sql is not null"
```

`sqlite_master` / `group_concat(…, sep)` / `CHAR(10)` are SQLite-only, so every `/<db>/-/schema` page (and `/-/schema`) returned a 500 on the DuckDB backend (`Parser Error`).

### Fix
Add `Introspector.database_schema()` with a default implementation that composes the schema from `get_table_definition` over `table_names()` + `view_names()` — backend-agnostic. The view now calls `db.database_schema()`.

`SqliteIntrospector` **overrides** it with the original `sqlite_master` query, so SQLite's `/-/schema` output (and `tests/test_schema_endpoints.py`) are byte-for-byte unchanged. The DuckDB backend uses the default, composing real `CREATE TABLE … PRIMARY KEY … FOREIGN KEY` DDL from `duckdb_tables()`/`duckdb_views()`.

### Verification
- `tests/test_schema_endpoints.py` (16) unchanged and green — SQLite output identical.
- New DuckDB regression test (`datasette-duckdb/tests/test_views.py`); full plugin suite (27) green.
- End-to-end: `/opdr/-/schema`, `.json`, and `/opdr/<table>/-/schema` all 200 (were 500).

Found via a real-traffic replay of labordata against the SQLite and DuckDB deployments (12 URLs / 43 hits — `/<db>/-/schema` for every database).

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--22.org.readthedocs.build/en/22/

<!-- readthedocs-preview datasette end -->