### PR TITLE
datasette-duckdb: advertise supports_glob=True

### DIFF
--- a/datasette-duckdb/datasette_duckdb/backend.py
+++ b/datasette-duckdb/datasette_duckdb/backend.py
@@ -141,7 +141,12 @@ class DuckDBBackend(Backend):
         supports_rowid=True,
         supports_fts=True,  # via the fts extension + match_bm25 (per-table index)
         supports_json=False,  # DuckDB has JSON, but not SQLite's json_each() shape
-        supports_glob=False,
+        # DuckDB has a native GLOB operator with the same semantics as SQLite:
+        # case-sensitive, * / ? / [..] wildcards. (Only divergence found vs SQLite
+        # is the ? wildcard against a leading invisible-unicode char, e.g. NBSP/ZWSP
+        # -- a fringe data artifact.) Enabling this offers the __glob filter in the
+        # table UI, matching the SQLite backend.
+        supports_glob=True,
         supports_load_extension=True,
         supports_attach=True,
         supports_write=False,  # read-only analytic browsing for now

--- a/datasette-duckdb/tests/test_views.py
+++ b/datasette-duckdb/tests/test_views.py
@@ -43,3 +43,33 @@ def test_fk_label_expansion_empty_result_does_not_500(tmp_path):
 
     response = asyncio.run(fetch())
     assert response.status_code == 200
+
+
+def test_glob_filter_offered_and_works(tmp_path):
+    # DuckDB supports the GLOB operator, so the backend advertises supports_glob
+    # and the __glob table filter must work (case-sensitive, * wildcard).
+    src = tmp_path / "source.db"
+    dst = tmp_path / "out.duckdb"
+    con = sqlite3.connect(str(src))
+    con.executescript("""
+        create table org (id integer primary key, name text);
+        insert into org (id, name) values
+            (1,'Alpha'), (2,'Apex'), (3,'Beacon'), (4,'apex lower');
+        """)
+    con.commit()
+    con.close()
+    convert_sqlite_to_duckdb(str(src), str(dst))
+
+    ds = Datasette(
+        config={"plugins": {"datasette-duckdb": {"databases": {"d": str(dst)}}}}
+    )
+
+    async def fetch():
+        await ds.invoke_startup()
+        return await ds.client.get("/d/org.json?name__glob=A*&_shape=array")
+
+    response = asyncio.run(fetch())
+    assert response.status_code == 200
+    names = sorted(r["name"] for r in response.json())
+    # case-sensitive: 'Alpha' and 'Apex' match 'A*', 'apex lower' does not
+    assert names == ["Alpha", "Apex"]


### PR DESCRIPTION
Fixes #23.

DuckDB supports the `GLOB` operator natively (`… where col glob 'A*'` runs fine), but `DuckDBBackend.features` declared `supports_glob=False`. That flag only gates the `__glob` **filter operator** in the table UI (`filters.py` maps `"glob" -> supports_glob`), so the DuckDB site was hiding a glob filter it can serve, while the SQLite backend (`supports_glob=True`) offers it — an inconsistency.

### Semantics verified (vs SQLite, real data)
Case-sensitive (`A*`=47775 vs `a*`=38 on both), and `*` / `?` / `[…]` / `*substr*` all match. Only divergence: the `?` wildcard against a leading **invisible-unicode** char (NBSP `\xa0`, ZWSP `​`) in 2 of millions of rows — a fringe data artifact, noted in a code comment.

### Safe
No hidden dependency — the base `date_facet_suggest_where` glob default is overridden by this backend (`try_cast`), so flipping the flag doesn't touch date faceting.

### Test
Adds a `__glob` filter regression test (case-sensitive `A*` match) in `datasette-duckdb/tests/test_views.py`; full plugin suite (27) green.

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--24.org.readthedocs.build/en/24/

<!-- readthedocs-preview datasette end -->