### PR TITLE
FK handling for the DuckDB backend: enforce what's enforceable + navigation sidecar (#18)

### DIFF
--- a/datasette-duckdb/datasette_duckdb/backend.py
+++ b/datasette-duckdb/datasette_duckdb/backend.py
@@ -319,41 +319,51 @@ class DuckDBIntrospector(Introspector):
         details = await self.table_column_details(table)
         return {col.name: (_python_type(col.type), bool(col.is_pk)) for col in details}
 
-    async def foreign_keys_for_table(self, table):
-        # Outbound single-column foreign keys (Datasette ignores compound FKs)
-        results = await self.db.execute(
-            "select constraint_column_names, referenced_table, "
-            "referenced_column_names from duckdb_constraints() "
-            "where schema_name = 'main' and table_name = :t "
-            "and constraint_type = 'FOREIGN KEY'",
-            {"t": table},
-        )
-        fks = []
-        for cols, other_table, other_cols in results.rows:
-            if len(cols) == 1 and len(other_cols) == 1:
-                fks.append(
-                    {
-                        "column": cols[0],
-                        "other_table": other_table,
-                        "other_column": other_cols[0],
-                    }
-                )
-        return fks
+    async def _single_col_fks(self):
+        """Every single-column FK as (table, from_col, other_table, other_col).
 
-    async def get_all_foreign_keys(self):
-        names = await self.table_names()
-        result = {name: {"incoming": [], "outgoing": []} for name in names}
+        Prefers the ``_datasette_foreign_keys`` sidecar the converter writes,
+        which lists ALL source FKs -- including ones DuckDB can't enforce because
+        the source data has orphans / incomplete parents (e.g. the NLRB CHIPS and
+        CATS archives). Datasette's related-rows / label-expansion only needs the
+        declared relationship, not enforcement. Falls back to the enforced catalog
+        constraints for .duckdb files built before the sidecar existed.
+        (Datasette ignores compound FKs, so only single-column ones are returned.)
+        """
+        has_sidecar = await self.db.execute(
+            "select 1 from information_schema.tables where table_schema = 'main' "
+            "and table_name = '_datasette_foreign_keys'"
+        )
+        if has_sidecar.rows:
+            results = await self.db.execute(
+                "select table_name, from_column, other_table, other_column "
+                "from _datasette_foreign_keys"
+            )
+            return [tuple(r) for r in results.rows]
         results = await self.db.execute(
             "select table_name, constraint_column_names, referenced_table, "
             "referenced_column_names from duckdb_constraints() "
             "where schema_name = 'main' and constraint_type = 'FOREIGN KEY'"
         )
-        for table_name, cols, other_table, other_cols in results.rows:
-            if len(cols) != 1 or len(other_cols) != 1:
-                continue
+        return [
+            (tn, cols[0], other_table, other_cols[0])
+            for tn, cols, other_table, other_cols in results.rows
+            if len(cols) == 1 and len(other_cols) == 1
+        ]
+
+    async def foreign_keys_for_table(self, table):
+        return [
+            {"column": fc, "other_table": ot, "other_column": oc}
+            for tn, fc, ot, oc in await self._single_col_fks()
+            if tn == table
+        ]
+
+    async def get_all_foreign_keys(self):
+        names = await self.table_names()
+        result = {name: {"incoming": [], "outgoing": []} for name in names}
+        for table_name, from_, other_table, to_ in await self._single_col_fks():
             if table_name not in result or other_table not in result:
                 continue
-            from_, to_ = cols[0], other_cols[0]
             result[table_name]["outgoing"].append(
                 {"other_table": other_table, "column": from_, "other_column": to_}
             )
@@ -374,7 +384,8 @@ class DuckDBIntrospector(Introspector):
         return table if results.rows else None
 
     async def hidden_table_names(self):
-        return []
+        # the FK-metadata sidecar is plumbing, not user data
+        return ["_datasette_foreign_keys"]
 
     async def get_table_definition(self, table, type_="table"):
         # DuckDB has no sqlite_master, but duckdb_tables()/duckdb_views() each

--- a/datasette-duckdb/datasette_duckdb/convert.py
+++ b/datasette-duckdb/datasette_duckdb/convert.py
@@ -188,10 +188,21 @@ def _read_schema(src):
     for t in tables:
         cols = cur.execute(f'PRAGMA table_info("{t}")').fetchall()
         pks = [c[1] for c in sorted(cols, key=lambda c: c[5]) if c[5]]
+        # Group foreign_key_list rows by FK id: a composite FK spans several rows
+        # (one per column). Each FK -> (from_cols, referenced_table, to_cols).
+        fk_groups = {}
+        for f in cur.execute(f'PRAGMA foreign_key_list("{t}")').fetchall():
+            if f[2] not in table_set:  # skip FKs to non-existent tables
+                continue
+            g = fk_groups.setdefault(f[0], {"ref": f[2], "cols": []})
+            g["cols"].append((f[1], f[3], f[4]))  # (seq, from, to)
         fks = [
-            (f[3], f[2], f[4])  # (from_column, referenced_table, to_column)
-            for f in cur.execute(f'PRAGMA foreign_key_list("{t}")').fetchall()
-            if f[2] in table_set  # skip FKs to non-existent tables
+            (
+                tuple(c[1] for c in sorted(g["cols"])),
+                g["ref"],
+                tuple(c[2] for c in sorted(g["cols"])),
+            )
+            for g in fk_groups.values()
         ]
         meta[t] = {
             "columns": [(c[1], _map_type(c[2])) for c in cols],
@@ -320,38 +331,54 @@ def _enforceable_fks(d, t, m, meta, dropped):
     """
     child_types = dict(m["columns"])
     keep = []
-    for frm, ref, to in m["fks"]:
+    for from_cols, ref, to_cols in m["fks"]:
         parent = meta.get(ref)
+        cols_label = ",".join(from_cols)
+        to_label = ",".join(to_cols)
         reason = None
         if parent is None:
             reason = "missing parent table"
-        elif child_types.get(frm) != dict(parent["columns"]).get(to):
-            reason = (
-                f"type mismatch ({child_types.get(frm)} vs "
-                f"{dict(parent['columns']).get(to)})"
-            )
-        elif parent["pks"] != [to]:
-            # enforceable only if the parent's PK is exactly this single column
-            # (composite or non-PK parents expose no usable unique key)
-            reason = f"{ref}.{to} is not a standalone PK"
+        elif set(to_cols) != set(parent["pks"]):
+            # enforceable only if the FK references exactly the parent's PK
+            # (DuckDB needs a unique key on the referenced columns; we only
+            # create PKs). Covers single, composite, and non-PK-parent cases.
+            reason = f"{ref}({to_label}) is not the parent PK"
         else:
-            # Orphan check in the TARGET type, matching how DuckDB will actually
-            # enforce the FK on the converted tables -- not raw VARCHAR. This
-            # avoids false orphans from TRY_CAST normalization (e.g. '' -> NULL,
-            # which is an allowed null FK; '01' vs '1' compare equal as BIGINT).
-            ty = child_types.get(frm)
-            cv = f'TRY_CAST(c."{frm}" AS {ty})'
-            orphan = d.execute(
-                f'SELECT 1 FROM s."{t}" c WHERE {cv} IS NOT NULL AND NOT EXISTS '
-                f'(SELECT 1 FROM s."{ref}" p WHERE TRY_CAST(p."{to}" AS {ty}) = {cv}) '
-                f"LIMIT 1"
-            ).fetchone()
-            if orphan:
-                reason = f"orphan rows reference {ref}.{to}"
+            ptypes = dict(parent["columns"])
+            mismatch = [
+                (fc, tc)
+                for fc, tc in zip(from_cols, to_cols)
+                if child_types.get(fc) != ptypes.get(tc)
+            ]
+            if mismatch:
+                reason = "type mismatch " + ", ".join(
+                    f"{fc}:{child_types.get(fc)} vs {tc}:{ptypes.get(tc)}"
+                    for fc, tc in mismatch
+                )
+            else:
+                # Orphan check in the TARGET type(s), matching how DuckDB will
+                # enforce on the converted tables -- not raw VARCHAR. Avoids false
+                # orphans from TRY_CAST normalization ('' -> NULL = allowed null
+                # FK; '01' vs '1' equal as BIGINT). Composite FK -> tuple match.
+                not_null = " AND ".join(
+                    f'TRY_CAST(c."{fc}" AS {child_types[fc]}) IS NOT NULL'
+                    for fc in from_cols
+                )
+                joined = " AND ".join(
+                    f'TRY_CAST(p."{tc}" AS {child_types[fc]}) '
+                    f'= TRY_CAST(c."{fc}" AS {child_types[fc]})'
+                    for fc, tc in zip(from_cols, to_cols)
+                )
+                orphan = d.execute(
+                    f'SELECT 1 FROM s."{t}" c WHERE {not_null} AND NOT EXISTS '
+                    f'(SELECT 1 FROM s."{ref}" p WHERE {joined}) LIMIT 1'
+                ).fetchone()
+                if orphan:
+                    reason = f"orphan rows reference {ref}({to_label})"
         if reason:
-            dropped.append((t, f'FK "{frm}" -> {ref}."{to}": {reason}'))
+            dropped.append((t, f"FK ({cols_label}) -> {ref}({to_label}): {reason}"))
         else:
-            keep.append((frm, ref, to))
+            keep.append((from_cols, ref, to_cols))
     return keep
 
 
@@ -411,8 +438,10 @@ def convert_sqlite_to_duckdb(src, dst, infer_types=True):
                     defs.append(
                         "PRIMARY KEY ({})".format(", ".join(f'"{p}"' for p in m["pks"]))
                     )
-                for frm, ref, to in fks:
-                    defs.append(f'FOREIGN KEY ("{frm}") REFERENCES "{ref}"("{to}")')
+                for from_cols, ref, to_cols in fks:
+                    fc = ", ".join(f'"{c}"' for c in from_cols)
+                    tc = ", ".join(f'"{c}"' for c in to_cols)
+                    defs.append(f'FOREIGN KEY ({fc}) REFERENCES "{ref}"({tc})')
                 d.execute(f'DROP TABLE IF EXISTS "{t}"')
                 d.execute(f'CREATE TABLE "{t}" ({", ".join(defs)})')
 

--- a/datasette-duckdb/datasette_duckdb/convert.py
+++ b/datasette-duckdb/datasette_duckdb/convert.py
@@ -463,6 +463,27 @@ def convert_sqlite_to_duckdb(src, dst, infer_types=True):
         # Tables (and their rowids) are populated now, so the FTS indexes can be
         # built against them.
         fts_created = _create_fts_indexes(d, fts)
+        # FK metadata sidecar: record EVERY single-column source FK (enforced or
+        # not) so Datasette can render related-rows / label-expansion for
+        # relationships DuckDB can't enforce -- e.g. an FK whose source data has
+        # orphans/incomplete parents (NLRB CHIPS/CATS archives). Enforcement is a
+        # data-integrity guarantee; navigation only needs the declared relationship.
+        # Read by DuckDBIntrospector; hidden from the table list there.
+        fk_rows = [
+            (t, fc[0], ref, tc[0])
+            for t in order
+            for fc, ref, tc in meta[t]["fks"]
+            if len(fc) == 1
+        ]
+        d.execute(
+            'CREATE TABLE "_datasette_foreign_keys" '
+            "(table_name VARCHAR, from_column VARCHAR, "
+            "other_table VARCHAR, other_column VARCHAR)"
+        )
+        if fk_rows:
+            d.executemany(
+                'INSERT INTO "_datasette_foreign_keys" VALUES (?, ?, ?, ?)', fk_rows
+            )
     finally:
         d.close()
     return dropped, promotions, fts_created

--- a/datasette-duckdb/datasette_duckdb/convert.py
+++ b/datasette-duckdb/datasette_duckdb/convert.py
@@ -335,11 +335,16 @@ def _enforceable_fks(d, t, m, meta, dropped):
             # (composite or non-PK parents expose no usable unique key)
             reason = f"{ref}.{to} is not a standalone PK"
         else:
-            # orphan check against the source (all-VARCHAR, matching SQLite's
-            # stored-value comparison); a non-NULL child with no parent fails.
+            # Orphan check in the TARGET type, matching how DuckDB will actually
+            # enforce the FK on the converted tables -- not raw VARCHAR. This
+            # avoids false orphans from TRY_CAST normalization (e.g. '' -> NULL,
+            # which is an allowed null FK; '01' vs '1' compare equal as BIGINT).
+            ty = child_types.get(frm)
+            cv = f'TRY_CAST(c."{frm}" AS {ty})'
             orphan = d.execute(
-                f'SELECT 1 FROM s."{t}" c WHERE c."{frm}" IS NOT NULL AND NOT EXISTS '
-                f'(SELECT 1 FROM s."{ref}" p WHERE p."{to}" = c."{frm}") LIMIT 1'
+                f'SELECT 1 FROM s."{t}" c WHERE {cv} IS NOT NULL AND NOT EXISTS '
+                f'(SELECT 1 FROM s."{ref}" p WHERE TRY_CAST(p."{to}" AS {ty}) = {cv}) '
+                f"LIMIT 1"
             ).fetchone()
             if orphan:
                 reason = f"orphan rows reference {ref}.{to}"

--- a/datasette-duckdb/datasette_duckdb/convert.py
+++ b/datasette-duckdb/datasette_duckdb/convert.py
@@ -16,9 +16,10 @@ tighter type: VARCHAR -> UUID / DATE / TIMESTAMP / BIGINT, and DOUBLE -> REAL
 (see that function and #9 for the precedence and the profiling behind it).
 
 DuckDB enforces foreign keys at insert and has no ``ALTER ... ADD FOREIGN KEY``,
-so tables are created in dependency order with inline FKs. Foreign keys that
-reference a missing table, or whose data has orphans, are dropped for that table
-(the data is still loaded) and reported.
+so tables are created in dependency order with inline FKs. Each FK DuckDB can't
+enforce -- referenced table/column isn't the parent's PK, a column-type mismatch,
+or orphan child rows -- is dropped INDIVIDUALLY (the others on the table survive;
+the data is still loaded) and reported. See ``_enforceable_fks``.
 
 Source FTS virtual tables (``sqlite-utils enable-fts``) are mirrored into
 equivalent DuckDB FTS indexes (``_read_fts`` / ``_create_fts_indexes``), so a
@@ -308,6 +309,47 @@ def _topo_order(tables, meta):
     return order
 
 
+def _enforceable_fks(d, t, m, meta, dropped):
+    """Subset of ``m['fks']`` DuckDB can enforce inline; the rest are dropped
+    INDIVIDUALLY (appended to ``dropped`` with a reason) rather than all-or-
+    nothing. DuckDB requires: the FK column's type matches the referenced
+    column, the referenced column is exactly the parent's PK (we only create
+    PKs, not other UNIQUE constraints), and no orphan child rows. SQLite enforces
+    none of this, so its schemas carry FKs DuckDB rejects -- but a single bad one
+    must not strip a table's good ones.
+    """
+    child_types = dict(m["columns"])
+    keep = []
+    for frm, ref, to in m["fks"]:
+        parent = meta.get(ref)
+        reason = None
+        if parent is None:
+            reason = "missing parent table"
+        elif child_types.get(frm) != dict(parent["columns"]).get(to):
+            reason = (
+                f"type mismatch ({child_types.get(frm)} vs "
+                f"{dict(parent['columns']).get(to)})"
+            )
+        elif parent["pks"] != [to]:
+            # enforceable only if the parent's PK is exactly this single column
+            # (composite or non-PK parents expose no usable unique key)
+            reason = f"{ref}.{to} is not a standalone PK"
+        else:
+            # orphan check against the source (all-VARCHAR, matching SQLite's
+            # stored-value comparison); a non-NULL child with no parent fails.
+            orphan = d.execute(
+                f'SELECT 1 FROM s."{t}" c WHERE c."{frm}" IS NOT NULL AND NOT EXISTS '
+                f'(SELECT 1 FROM s."{ref}" p WHERE p."{to}" = c."{frm}") LIMIT 1'
+            ).fetchone()
+            if orphan:
+                reason = f"orphan rows reference {ref}.{to}"
+        if reason:
+            dropped.append((t, f'FK "{frm}" -> {ref}."{to}": {reason}'))
+        else:
+            keep.append((frm, ref, to))
+    return keep
+
+
 def convert_sqlite_to_duckdb(src, dst, infer_types=True):
     """Convert SQLite db at ``src`` to a DuckDB file at ``dst`` (overwritten).
 
@@ -354,27 +396,36 @@ def convert_sqlite_to_duckdb(src, dst, infer_types=True):
                 for n, ty in m["columns"]
             )
 
-            def create(with_fks):
+            # Only keep FKs DuckDB can actually enforce; drop the rest INDIVIDUALLY
+            # (not all-or-nothing) so one bad FK doesn't strip a table's good ones.
+            keep_fks = _enforceable_fks(d, t, m, meta, dropped)
+
+            def create(fks):
                 defs = [f'"{n}" {ty}' for n, ty in m["columns"]]
                 if m["pks"]:
                     defs.append(
                         "PRIMARY KEY ({})".format(", ".join(f'"{p}"' for p in m["pks"]))
                     )
-                if with_fks:
-                    for frm, ref, to in m["fks"]:
-                        defs.append(f'FOREIGN KEY ("{frm}") REFERENCES "{ref}"("{to}")')
+                for frm, ref, to in fks:
+                    defs.append(f'FOREIGN KEY ("{frm}") REFERENCES "{ref}"("{to}")')
                 d.execute(f'DROP TABLE IF EXISTS "{t}"')
                 d.execute(f'CREATE TABLE "{t}" ({", ".join(defs)})')
 
             try:
-                create(with_fks=True)
+                create(keep_fks)
                 d.execute(f'INSERT INTO "{t}" SELECT {select} FROM s."{t}"')
             except duckdb.Error as e:
-                # Orphan FK (or other constraint) -> keep the data, drop the FKs
-                create(with_fks=False)
+                # Anything the pre-checks missed -> keep the data, drop FKs.
+                create([])
                 d.execute(f'INSERT INTO "{t}" SELECT {select} FROM s."{t}"')
-                if m["fks"]:
-                    dropped.append((t, str(e).splitlines()[0]))
+                if keep_fks:
+                    dropped.append(
+                        (
+                            t,
+                            f"all FKs dropped (create/insert failed): "
+                            f"{str(e).splitlines()[0]}",
+                        )
+                    )
         # Tables (and their rowids) are populated now, so the FTS indexes can be
         # built against them.
         fts_created = _create_fts_indexes(d, fts)

--- a/datasette-duckdb/tests/test_convert.py
+++ b/datasette-duckdb/tests/test_convert.py
@@ -321,3 +321,41 @@ def test_fts_index_mirrored_and_searchable(tmp_path):
         ]
     finally:
         d.close()
+
+
+def test_one_bad_fk_does_not_drop_a_tables_good_fks(tmp_path):
+    # Regression (#18): a single un-enforceable FK used to make the converter drop
+    # ALL of a table's FKs (create-with-all-fks failed -> fallback with none).
+    # Now un-enforceable FKs are dropped individually; valid siblings survive.
+    src = tmp_path / "s.db"
+    dst = tmp_path / "d.duckdb"
+    con = sqlite3.connect(str(src))
+    con.executescript("""
+        CREATE TABLE region (id INTEGER PRIMARY KEY, name TEXT);
+        CREATE TABLE office (
+            id        INTEGER PRIMARY KEY,
+            region_id INTEGER REFERENCES region(id),   -- valid
+            ghost_id  INTEGER REFERENCES region(id)     -- orphan -> can't enforce
+        );
+        INSERT INTO region VALUES (1, 'Midwest');
+        INSERT INTO office VALUES (1, 1, 999);          -- ghost_id 999: no such region
+        """)
+    con.commit()
+    con.close()
+    dropped, _, _ = convert_sqlite_to_duckdb(str(src), str(dst))
+
+    d = duckdb.connect(str(dst))
+    fk_cols = {
+        row[0][0]
+        for row in d.execute(
+            "select constraint_column_names from duckdb_constraints() "
+            "where table_name='office' and constraint_type='FOREIGN KEY'"
+        ).fetchall()
+    }
+    n = d.execute("select count(*) from office").fetchone()[0]
+    d.close()
+
+    assert "region_id" in fk_cols  # valid FK survived its bad sibling
+    assert "ghost_id" not in fk_cols  # orphan FK dropped individually
+    assert any("ghost_id" in msg for _, msg in dropped)
+    assert n == 1  # data intact

--- a/datasette-duckdb/tests/test_convert.py
+++ b/datasette-duckdb/tests/test_convert.py
@@ -359,3 +359,42 @@ def test_one_bad_fk_does_not_drop_a_tables_good_fks(tmp_path):
     assert "ghost_id" not in fk_cols  # orphan FK dropped individually
     assert any("ghost_id" in msg for _, msg in dropped)
     assert n == 1  # data intact
+
+
+def test_composite_fk_recreated(tmp_path):
+    # Composite FKs span several PRAGMA rows; the converter used to flatten them
+    # to single columns (-> "not the parent PK", dropped). They should now be
+    # recreated as a real multi-column FK when they reference the parent's
+    # composite PK. Regression for cats r_* -> r_bargaining_unit (#18).
+    src = tmp_path / "s.db"
+    dst = tmp_path / "d.duckdb"
+    con = sqlite3.connect(str(src))
+    con.executescript("""
+        CREATE TABLE unit (
+            case_no TEXT, unit_id INTEGER, name TEXT,
+            PRIMARY KEY (case_no, unit_id)
+        );
+        CREATE TABLE action (
+            id INTEGER PRIMARY KEY,
+            case_no TEXT,
+            unit_id INTEGER,
+            FOREIGN KEY (case_no, unit_id) REFERENCES unit(case_no, unit_id)
+        );
+        INSERT INTO unit VALUES ('A', 1, 'x');
+        INSERT INTO action VALUES (1, 'A', 1);
+        """)
+    con.commit()
+    con.close()
+    dropped, _, _ = convert_sqlite_to_duckdb(str(src), str(dst))
+
+    d = duckdb.connect(str(dst))
+    fk_cols = [
+        sorted(row[0])
+        for row in d.execute(
+            "select constraint_column_names from duckdb_constraints() "
+            "where table_name='action' and constraint_type='FOREIGN KEY'"
+        ).fetchall()
+    ]
+    d.close()
+    assert fk_cols == [["case_no", "unit_id"]]  # one composite FK, both columns
+    assert not [m for _, m in dropped if "action" in m]

--- a/datasette-duckdb/tests/test_views.py
+++ b/datasette-duckdb/tests/test_views.py
@@ -43,3 +43,55 @@ def test_fk_label_expansion_empty_result_does_not_500(tmp_path):
 
     response = asyncio.run(fetch())
     assert response.status_code == 200
+
+
+def test_unenforceable_fk_still_navigable_via_sidecar(tmp_path):
+    # An FK whose source data has orphans can't be enforced by DuckDB, so it's
+    # absent from the catalog constraints -- but the converter's FK sidecar still
+    # records it, so Datasette renders related-rows / label-expansion (parity with
+    # SQLite, which declares-but-doesn't-enforce). #18.
+    import duckdb
+
+    src = tmp_path / "s.db"
+    dst = tmp_path / "d.duckdb"
+    con = sqlite3.connect(str(src))
+    con.executescript("""
+        CREATE TABLE region (id INTEGER PRIMARY KEY, name TEXT);
+        CREATE TABLE office (
+            id INTEGER PRIMARY KEY,
+            region_id INTEGER REFERENCES region(id)
+        );
+        INSERT INTO region VALUES (1, 'Midwest');
+        INSERT INTO office VALUES (1, 1), (2, 999);  -- 999 orphan -> not enforceable
+        """)
+    con.commit()
+    con.close()
+    convert_sqlite_to_duckdb(str(src), str(dst))
+
+    # genuinely NOT an enforced constraint (orphan data)
+    enforced = (
+        duckdb.connect(str(dst), read_only=True)
+        .execute(
+            "select count(*) from duckdb_constraints() "
+            "where table_name = 'office' and constraint_type = 'FOREIGN KEY'"
+        )
+        .fetchone()[0]
+    )
+    assert enforced == 0
+
+    ds = Datasette(
+        config={"plugins": {"datasette-duckdb": {"databases": {"d": str(dst)}}}}
+    )
+
+    async def fetch():
+        await ds.invoke_startup()
+        fks = await ds.databases["d"].foreign_keys_for_table("office")
+        row = await ds.client.get("/d/office/1")  # a row page that uses FK labels
+        return fks, row.status_code
+
+    fks, status = asyncio.run(fetch())
+    # navigation is restored from the sidecar despite no enforced constraint
+    assert fks == [
+        {"column": "region_id", "other_table": "region", "other_column": "id"}
+    ]
+    assert status == 200


### PR DESCRIPTION
Fixes #18.

SQLite never enforces foreign keys, so the warehouse schemas carry FKs DuckDB can't recreate — and the converter's all-or-nothing fallback meant one bad FK stripped a whole table's FKs, so the DuckDB site lost related-rows + label-expansion wholesale. This reworks FK handling end to end.

### 1. Enforce the enforceable subset, individually
`_enforceable_fks` keeps only FKs DuckDB can enforce — referenced column is the parent PK, column types match, no orphan rows (checked in the **target type**, matching DuckDB's enforcement, not raw VARCHAR) — and drops the rest **individually** with a reason, instead of all-or-nothing. **Composite FKs** are now grouped from `foreign_key_list` and emitted as real multi-column constraints. Recovered enforced FKs: chips 0→9, opdr 22→29, cats 60→98.

### 2. Navigation sidecar (the part that restores related-rows)
Most still-dropped FKs are **un-enforceable because the source data is inherently incomplete** — the NLRB CHIPS (1984–2000) and CATS (1999–2010) National-Archives files have detail rows referencing master/parent rows that simply aren't in the archive (verified against the raw NARA files; ~28k for chips, not fixable upstream). DuckDB won't declare an FK with orphans, so navigation died for the *whole* relationship, including the clean majority.

Datasette's related-rows / label-expansion only need the **declared relationship**, not enforcement. So the converter writes a `_datasette_foreign_keys` sidecar listing every single-column source FK (enforced or not); `DuckDBIntrospector.foreign_keys_for_table` / `get_all_foreign_keys` read it (falling back to the catalog for older files) and hide it. Enforcement stays for data integrity on the enforceable subset; navigation matches the SQLite site for all declared FKs.

e.g. chips: 9 FKs enforced, **all 43 navigable** — `c_names → c_master` related-rows restored despite 28k orphan rows.

### Tests
`test_convert.py`: individual-drop, composite recreate. `test_views.py`: un-enforceable FK still navigable via sidecar. Full plugin suite (29) green.

(Source data bugs surfaced by the audit filed upstream: labordata/nlrb-data#47/#48/#49, labordata/opdr#5. Audit tool: labordata_firewall `scripts/fk-audit.py`.)