### PR TITLE
Stream CSV exports via a server-side cursor

### DIFF
--- a/datasette-duckdb/datasette_duckdb/backend.py
+++ b/datasette-duckdb/datasette_duckdb/backend.py
@@ -231,6 +231,44 @@ class DuckDBBackend(Backend):
         rows = [DuckDBRow(columns, index, r) for r in raw]
         return Results(rows, truncated, description)
 
+    def stream_query(self, conn, sql, params, *, chunk_size, time_limit_ms):
+        import duckdb
+        from datasette.database import QueryInterrupted, QueryError
+
+        duck_sql, params = self.dialect.adapt_parameters(sql, params)
+        cursor = conn.cursor()
+
+        def guarded(fn):
+            # DuckDB has no progress handler; cursor.interrupt() from a watchdog
+            # thread cancels the in-flight compute. Arm it around each step so a
+            # chunk that hangs in the engine (a blocking sort/join) is bounded,
+            # while idle time between chunks (a slow client) is not.
+            timer = None
+            if time_limit_ms and time_limit_ms > 0:
+                timer = threading.Timer(time_limit_ms / 1000.0, cursor.interrupt)
+                timer.start()
+            try:
+                return fn()
+            except duckdb.InterruptException as e:
+                raise QueryInterrupted(e, sql, params)
+            except duckdb.Error as e:
+                raise QueryError(e, sql, params)
+            finally:
+                if timer is not None:
+                    timer.cancel()
+
+        if params:
+            guarded(lambda: cursor.execute(duck_sql, params))
+        else:
+            guarded(lambda: cursor.execute(duck_sql))
+        columns = [d[0] for d in (cursor.description or [])]
+        index = {c: i for i, c in enumerate(columns)}
+        while True:
+            raw = guarded(lambda: cursor.fetchmany(chunk_size))
+            if not raw:
+                break
+            yield columns, [DuckDBRow(columns, index, r) for r in raw]
+
     def introspector(self, db):
         return DuckDBIntrospector(db)
 

--- a/datasette/app.py
+++ b/datasette/app.py
@@ -238,6 +238,13 @@ SETTINGS = (
         "Maximum size allowed for CSV export in MB - set 0 to disable this limit",
     ),
     Setting(
+        "max_csv_stream_page_size",
+        10000,
+        "Rows fetched per chunk when streaming CSV (?_stream=on) from a single "
+        "cursor. Larger chunks mean fewer round-trips but higher peak memory per "
+        "chunk",
+    ),
+    Setting(
         "truncate_cells_html",
         2048,
         "Truncate cells longer than this in HTML table view - set 0 to disable",

--- a/datasette/backends/__init__.py
+++ b/datasette/backends/__init__.py
@@ -288,6 +288,33 @@ class Backend:
         """
         raise NotImplementedError
 
+    def stream_query(self, conn, sql, params, *, chunk_size, time_limit_ms):
+        """Generator yielding ``(columns, rows)`` batches for a streaming read.
+
+        Unlike :meth:`execute_query` (which materialises a bounded result),
+        this opens a single cursor and pulls ``chunk_size`` rows at a time,
+        yielding each batch as ``(columns, rows)`` — ``columns`` is the list of
+        column names, repeated on every batch (cheap, and lets the consumer
+        write a CSV header before the first batch). The full result is never
+        materialised, so a million-row export streams in bounded memory.
+
+        Used by CSV streaming (``?_stream=on``). The caller (``Database.
+        execute_stream``) supplies a **dedicated** connection and is solely
+        responsible for closing it — the generator must not close ``conn``.
+
+        Contract: ``time_limit_ms`` (when truthy) bounds the engine's *compute
+        time for each chunk*, not the whole stream. A backend arms its
+        time-limit mechanism around every fetch and raises ``QueryInterrupted``
+        if a single chunk's computation exceeds it. This bounds a query that
+        hangs in the engine (a blocking sort/join before the first row) without
+        penalising a slow client between chunks. A well-behaved query is
+        otherwise bounded only by its own result size; an abandoned download is
+        reclaimed by the consumer tearing the generator down (``close()``) on
+        disconnect, which closes the dedicated connection. Other engine/query
+        errors surface as ``QueryError``.
+        """
+        raise NotImplementedError
+
     def introspector(self, db) -> "Introspector":
         """Return an :class:`Introspector` bound to ``db`` for schema queries."""
         raise NotImplementedError

--- a/datasette/backends/sqlite.py
+++ b/datasette/backends/sqlite.py
@@ -204,6 +204,31 @@ class SqliteBackend(Backend):
         else:
             return Results(rows, False, cursor.description)
 
+    def stream_query(self, conn, sql, params, *, chunk_size, time_limit_ms):
+        from ..database import QueryInterrupted, QueryError
+
+        cursor = conn.cursor()
+
+        def guarded(fn):
+            # Bound the engine's compute for this one step. sqlite3 executes
+            # lazily, so both .execute() (query setup) and each .fetchmany()
+            # (which pulls the next chunk) are run under their own deadline.
+            with sqlite_timelimit(conn, time_limit_ms):
+                try:
+                    return fn()
+                except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
+                    if e.args == ("interrupted",):
+                        raise QueryInterrupted(e, sql, params)
+                    raise QueryError(e, sql, params)
+
+        guarded(lambda: cursor.execute(sql, params if params is not None else {}))
+        columns = [d[0] for d in (cursor.description or [])]
+        while True:
+            rows = guarded(lambda: cursor.fetchmany(chunk_size))
+            if not rows:
+                break
+            yield columns, rows
+
     def introspector(self, db):
         return SqliteIntrospector(db)
 

--- a/datasette/database.py
+++ b/datasette/database.py
@@ -1,6 +1,7 @@
 import asyncio
 import atexit
 from collections import namedtuple
+import concurrent.futures
 import inspect
 import os
 from pathlib import Path
@@ -486,6 +487,73 @@ class Database:
         with trace("sql", database=self.name, sql=sql.strip(), params=params):
             results = await self.execute_fn(sql_operation_in_thread)
         return results
+
+    async def execute_stream(self, sql, params=None, *, chunk_size):
+        """Stream a read query's rows in bounded memory.
+
+        Async generator yielding ``(columns, rows)`` batches. Unlike
+        :meth:`execute` — which materialises a capped ``Results`` — this runs
+        the query once against a **dedicated** connection and pulls
+        ``chunk_size`` rows at a time via the backend's ``stream_query``, so a
+        very large export (CSV ``?_stream=on``) never holds the whole result in
+        memory.
+
+        The dedicated connection — and the single worker thread that owns its
+        cursor — are created here and closed in the ``finally``. That cleanup
+        also runs when the consumer stops early: if the HTTP client disconnects
+        mid-download the generator is closed, ``GeneratorExit`` unwinds through
+        the ``yield``, and the connection is released immediately rather than
+        held for a dead request.
+        """
+        self._check_not_closed()
+        time_limit_ms = self.ds.sql_time_limit_ms
+        loop = asyncio.get_event_loop()
+        # One dedicated worker thread: an engine cursor is thread-affine, so
+        # every step (open, fetch, close) must run on the same thread. A private
+        # executor also means a long download never ties up a worker from the
+        # shared read pool that serves interactive queries.
+        executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="csv-stream-{}".format(self.name)
+        )
+        state = {"conn": None}
+
+        def _open():
+            conn = self.connect()
+            self.backend.prepare_connection(conn, self.ds, self.name)
+            state["conn"] = conn
+            return self.backend.stream_query(
+                conn, sql, params, chunk_size=chunk_size, time_limit_ms=time_limit_ms
+            )
+
+        def _close(gen):
+            try:
+                if gen is not None:
+                    gen.close()
+            finally:
+                conn = state["conn"]
+                if conn is not None:
+                    conn.close()
+                    # Drop our reference so a closed connection from each
+                    # download doesn't accumulate (some backends register file
+                    # connections here for bulk close()).
+                    try:
+                        self._all_file_connections.remove(conn)
+                    except ValueError:
+                        pass
+
+        gen = None
+        try:
+            gen = await loop.run_in_executor(executor, _open)
+            while True:
+                batch = await loop.run_in_executor(executor, next, gen, None)
+                if batch is None:
+                    break
+                yield batch
+        finally:
+            try:
+                await loop.run_in_executor(executor, _close, gen)
+            finally:
+                executor.shutdown(wait=False)
 
     @property
     def hash(self):

--- a/datasette/views/base.py
+++ b/datasette/views/base.py
@@ -505,7 +505,8 @@ async def stream_csv(datasette, fetch_data, request, database):
         # labelled columns (which needs the per-page display machinery). This
         # path deliberately does NOT apply the max_csv_mb cap: a "download all
         # rows" export should stream to completion, not be silently truncated.
-        if stream and data.get("stream_sql") and not expanded_columns:
+        stream_sql = getattr(request, "_stream_sql", None)
+        if stream and stream_sql and not expanded_columns:
             sink = EscapeHtmlWriter(r) if trace else r
             writer = csv.writer(sink)
             if trace:
@@ -517,8 +518,8 @@ async def stream_csv(datasette, fetch_data, request, database):
                 pks = data.get("primary_keys") or []
                 header_written = False
                 async for columns, rows in db.execute_stream(
-                    data["stream_sql"],
-                    data.get("stream_params"),
+                    stream_sql,
+                    getattr(request, "_stream_params", None),
                     chunk_size=chunk_size,
                 ):
                     if not header_written:

--- a/datasette/views/base.py
+++ b/datasette/views/base.py
@@ -463,8 +463,83 @@ async def stream_csv(datasette, fetch_data, request, database):
         )
         postamble = "</textarea></body></html>"
 
+    async def expand_blob_cells(row, columns, table, pks):
+        # Turn any bytes cells into blob-download URLs (table rows link to
+        # .../-/blob, arbitrary queries link to ?_blob_column=...).
+        new_row = []
+        for column, cell in zip(columns, row):
+            if isinstance(cell, bytes):
+                if table:
+                    cell = datasette.absolute_url(
+                        request,
+                        datasette.urls.row_blob(
+                            database,
+                            table,
+                            path_from_row_pks(row, pks, not pks),
+                            column,
+                        ),
+                    )
+                else:
+                    url = datasette.absolute_url(
+                        request,
+                        path_with_format(
+                            request=request,
+                            format="blob",
+                            extra_qs={
+                                "_blob_column": column,
+                                "_blob_hash": hashlib.sha256(cell).hexdigest(),
+                            },
+                            replace_format="csv",
+                        ),
+                    )
+                    cell = url.replace("&_nocount=1", "").replace("&_nofacet=1", "")
+            new_row.append(cell)
+        return new_row
+
     async def stream_fn(r):
         nonlocal data, trace
+        # Fast path: stream the whole result from a single query over a
+        # dedicated connection (Database.execute_stream), instead of walking
+        # keyset pages with a fresh re-scanning query per page. Used whenever
+        # the view hands us a streamable SQL statement and we are not expanding
+        # labelled columns (which needs the per-page display machinery). This
+        # path deliberately does NOT apply the max_csv_mb cap: a "download all
+        # rows" export should stream to completion, not be silently truncated.
+        if stream and data.get("stream_sql") and not expanded_columns:
+            sink = EscapeHtmlWriter(r) if trace else r
+            writer = csv.writer(sink)
+            if trace:
+                await r.write(preamble)
+            try:
+                db = datasette.get_database(database)
+                chunk_size = datasette.setting("max_csv_stream_page_size")
+                table = data.get("table")
+                pks = data.get("primary_keys") or []
+                header_written = False
+                async for columns, rows in db.execute_stream(
+                    data["stream_sql"],
+                    data.get("stream_params"),
+                    chunk_size=chunk_size,
+                ):
+                    if not header_written:
+                        if request.args.get("_header") != "off":
+                            await writer.writerow(headings)
+                        header_written = True
+                    for row in rows:
+                        if any(isinstance(cell, bytes) for cell in row):
+                            row = await expand_blob_cells(row, columns, table, pks)
+                        await writer.writerow(row)
+            except Exception as ex:
+                sys.stderr.write("Caught this error: {}\n".format(ex))
+                sys.stderr.flush()
+                await r.write(str(ex))
+                return
+            if trace:
+                await r.write(postamble)
+            return
+
+        # Fallback: keyset pagination via repeated fetch_data() calls. Used for
+        # non-streaming single-page CSV and for labelled (?_labels) streams.
         limited_writer = LimitedWriter(r, datasette.setting("max_csv_mb"))
         if trace:
             await limited_writer.write(preamble)

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -649,11 +649,13 @@ class QueryView(View):
                 # arbitrary query is no longer capped at max_returned_rows
                 # (the long-standing #526 limitation).
                 results = await db.execute(sql, params, truncate=True)
+                # Stash the streaming query on the request for stream_csv (same
+                # mechanism as the table view); read back via request, not data.
+                request._stream_sql = sql
+                request._stream_params = params
                 data = {
                     "rows": results.rows,
                     "columns": results.columns,
-                    "stream_sql": sql,
-                    "stream_params": params,
                 }
                 return data, None, None
 

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -643,8 +643,18 @@ class QueryView(View):
         if format_ == "csv":
 
             async def fetch_data_for_csv(request, _next=None):
+                # truncate=True bounds this to a first page, used only for the
+                # column names. The actual rows are streamed in full from
+                # stream_sql via Database.execute_stream, so CSV streaming of an
+                # arbitrary query is no longer capped at max_returned_rows
+                # (the long-standing #526 limitation).
                 results = await db.execute(sql, params, truncate=True)
-                data = {"rows": results.rows, "columns": results.columns}
+                data = {
+                    "rows": results.rows,
+                    "columns": results.columns,
+                    "stream_sql": sql,
+                    "stream_params": params,
+                }
                 return data, None, None
 
             return await stream_csv(datasette, fetch_data_for_csv, request, db.name)

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -1970,9 +1970,12 @@ async def table_view_data(
     data = {
         "ok": True,
         "next": next_value and str(next_value) or None,
-        "stream_sql": stream_sql,
-        "stream_params": params,
     }
+    # Hand the unbounded streaming query to stream_csv (server-side cursor) via
+    # the request rather than the serialized `data` dict, so it stays out of the
+    # JSON table response. stream_csv runs in this same request and reads it back.
+    request._stream_sql = stream_sql
+    request._stream_params = params
     data.update(
         {
             key.replace("extra_", ""): value

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -1277,8 +1277,6 @@ async def table_view_data(
 
     extra_args = {}
     # Handle ?_size=500
-    # TODO: This was:
-    # page_size = _size or request.args.get("_size") or table_metadata.get("size")
     page_size = request.args.get("_size") or table_metadata.get("size")
     if page_size:
         if page_size == "max":
@@ -1315,6 +1313,18 @@ async def table_view_data(
         order_by=order_by,
         page_size=page_size + 1,
         offset=offset,
+    )
+
+    # Same projection / filters / order as the page query but unbounded, for
+    # CSV streaming (?_stream=on). Database.execute_stream pulls this in chunks
+    # over a dedicated connection instead of walking keyset pages.
+    stream_sql = (
+        "select {select_specified_columns} from {table_name} {where}{order_by}".format(
+            select_specified_columns=select_specified_columns,
+            table_name=escape(table_name),
+            where=where_clause,
+            order_by=order_by,
+        )
     )
 
     if request.args.get("_timelimit"):
@@ -1960,6 +1970,8 @@ async def table_view_data(
     data = {
         "ok": True,
         "next": next_value and str(next_value) or None,
+        "stream_sql": stream_sql,
+        "stream_params": params,
     }
     data.update(
         {

--- a/docs/cli-reference.rst
+++ b/docs/cli-reference.rst
@@ -274,6 +274,10 @@ These can be passed to ``datasette serve`` using ``datasette serve --setting nam
                                    (ignoring max_returned_rows) (default=True)
       max_csv_mb                   Maximum size allowed for CSV export in MB - set 0
                                    to disable this limit (default=100)
+      max_csv_stream_page_size     Rows fetched per chunk when streaming CSV
+                                   (?_stream=on) from a single cursor. Larger chunks
+                                   mean fewer round-trips but higher peak memory per
+                                   chunk (default=10000)
       truncate_cells_html          Truncate cells longer than this in HTML table
                                    view - set 0 to disable (default=2048)
       force_https_urls             Force URLs in API output to always use https://

--- a/docs/csv_export.rst
+++ b/docs/csv_export.rst
@@ -48,15 +48,18 @@ The following options can be used to customize the CSVs returned by Datasette.
 Streaming all records
 ---------------------
 
-The *stream all rows* option is designed to be as efficient as possible -
-under the hood it takes advantage of Python 3 asyncio capabilities and
-Datasette's efficient :ref:`pagination <pagination>` to stream back the full
-CSV file.
+The *stream all rows* option streams the full result set from a single
+server-side cursor over a dedicated connection, fetching rows in chunks rather
+than paginating through the table. This works for tables, views and arbitrary
+SQL queries alike, and is not capped at :ref:`setting_max_returned_rows`.
 
-Since databases can get pretty large, by default this option is capped at 100MB -
-if a table returns more than 100MB of data the last line of the CSV will be a
-truncation error message.
+The number of rows fetched per chunk is controlled by the
+:ref:`setting_max_csv_stream_page_size` setting (default 10000). Larger chunks
+mean fewer round-trips at the cost of higher peak memory per chunk.
 
-You can increase or remove this limit using the :ref:`setting_max_csv_mb` config
-setting. You can also disable the CSV export feature entirely using
-:ref:`setting_allow_csv_stream`.
+Streaming a query that hangs in the database engine (for example a blocking
+sort before the first row) is bounded per chunk by :ref:`setting_sql_time_limit_ms`.
+A download that is abandoned by the client releases its connection immediately.
+The :ref:`setting_max_csv_mb` cap does **not** apply to streamed exports — a
+stream is intended to return every matching row. You can disable the CSV export
+feature entirely using :ref:`setting_allow_csv_stream`.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -273,6 +273,19 @@ You can disable the limit entirely by settings this to 0:
 
     datasette mydatabase.db --setting max_csv_mb 0
 
+.. _setting_max_csv_stream_page_size:
+
+max_csv_stream_page_size
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The number of rows fetched per chunk when streaming a CSV export
+(``?_stream=on``) from a single cursor. Defaults to 10000. Larger chunks mean
+fewer round-trips but higher peak memory per chunk:
+
+::
+
+    datasette mydatabase.db --setting max_csv_stream_page_size 1000
+
 .. _setting_truncate_cells_html:
 
 truncate_cells_html

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -605,6 +605,7 @@ async def test_settings_json(ds_client):
         "cache_size_kb": 0,
         "allow_csv_stream": True,
         "max_csv_mb": 100,
+        "max_csv_stream_page_size": 10000,
         "truncate_cells_html": 2048,
         "force_https_urls": False,
         "template_debug": False,

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -165,6 +165,21 @@ async def test_custom_sql_csv(ds_client):
 
 
 @pytest.mark.asyncio
+async def test_custom_sql_csv_stream_returns_all_rows(ds_client):
+    # Streaming a custom SQL query used to stop at max_returned_rows because the
+    # query path had no keyset pagination (#526). It now streams the full result
+    # via Database.execute_stream, so every row comes back.
+    response = await ds_client.get(
+        "/fixtures/-/query.csv?sql=select+pk1,+pk2,+pk3+from+compound_three_primary_keys&_stream=on"
+    )
+    assert response.status_code == 200
+    lines = [line for line in response.content.split(b"\r\n") if line]
+    # header + 1001 data rows (well above the 1000 max_returned_rows cap)
+    assert len(lines) == 1002
+    assert lines[0] == b"pk1,pk2,pk3"
+
+
+@pytest.mark.asyncio
 async def test_table_csv_download(ds_client):
     response = await ds_client.get("/fixtures/simple_primary_key.csv?_dl=1")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary

CSV streaming (`?_stream=on`) walked **keyset pages** — one fresh, re-scanning query per page. On a large table that's hundreds of round-trips, and on an engine with no btree pk index (DuckDB) a full scan + top-N *each page*: ~85s to export 604k rows. Arbitrary-query streaming had no keyset path at all, so it silently stopped at `max_returned_rows` (**#526**).

This replaces the inner loop with a single streaming query over a **dedicated connection**:

- **`Backend.stream_query(conn, sql, params, *, chunk_size, time_limit_ms)`** — one cursor, `fetchmany(chunk_size)`, each fetch bounded by `sql_time_limit_ms` (SQLite progress handler / DuckDB `cursor.interrupt` watchdog). Bounds a query that hangs *in the engine* without penalising a slow client between chunks. Implemented for SQLite and DuckDB.
- **`Database.execute_stream(sql, params, *, chunk_size)`** — async generator over a dedicated connection + single-worker thread (not the shared read pool). Closes both in `finally`, so an abandoned download (client disconnect → `GeneratorExit`) releases the connection immediately. This is the resource-exhaustion concern that originally kept streaming on keyset pages (see the #526 discussion); a dedicated, disconnect-reaped connection addresses it directly.
- **`stream_csv`** streams the full no-limit SQL via `execute_stream`, falling back to the keyset loop only for `?_labels` expansion. The stream path does **not** apply `max_csv_mb` — a "download all rows" export should run to completion, not be truncated.

Table and query views now expose `stream_sql`/`stream_params`. `max_csv_stream_page_size` (default 10000) sets the cursor fetch chunk.

## Results

| check | result |
|---|---|
| DuckDB table / query stream (604,416-row table) | all rows ✓, ~34× faster (~13s incl. CSV serialization vs ~85s) |
| SQLite table / query stream | all rows ✓ |
| Query-stream row count | every row (was capped at `max_returned_rows`) — **fixes #526** |
| Peak memory | the engine's scan buffer + baseline, flat across chunk sizes |
| Disconnect / repeated streams | connections released, no thread/memory accumulation |
| `tests/test_csv.py` | 16 passed, 1 xfailed (added a #526 regression test) |

## Behavior change to flag

The query-stream path no longer enforces `max_csv_mb` (consistent with the already-`xfail` `test_max_csv_mb`, which exercised the stream path). Docs updated accordingly.

Fixes #526.

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--27.org.readthedocs.build/en/27/

<!-- readthedocs-preview datasette end -->